### PR TITLE
Ong and RCG Rhetoric for read.rerum.io

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,8 +16,7 @@
     <ng-view></ng-view>
 
     <small style="position: fixed;bottom: 0;right: 0;">
-        Walter J. Ong,
-        <small>S.J.</small> Center for Digital Humanities
+        Research Computing Group
         <a href="https://github.com/CenterForDigitalHumanities">
             <img alt="@CenterForDigitalHumanities" class="avatar" height="48" src="https://avatars3.githubusercontent.com/u/13770519?v=4&amp;s=96"
                 width="48">


### PR DESCRIPTION
Swap out or combine the mentions of Digital Humanities and Research Computing Group in page text.